### PR TITLE
Fix typo in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quick Start: Python and MariaDB
 
-This repository will walk you through the process of quickly getting started with [Node.js](https://www.python.org/) and [MariaDB](https://github.com/mariadb-developers/mariadb-getting-started) using the [MariaDB Python connector](https://github.com/mariadb-corporation/mariadb-connector-python).
+This repository will walk you through the process of quickly getting started with [python3](https://www.python.org/) and [MariaDB](https://github.com/mariadb-developers/mariadb-getting-started) using the [MariaDB Python connector](https://github.com/mariadb-corporation/mariadb-connector-python).
 
 <p align="center" spacing="10">
     <kbd>


### PR DESCRIPTION
Fix a typo in readme which referenced that the tutorial was about nodejs instead of python.